### PR TITLE
updates getBlockName for custom Fuxt blocks

### DIFF
--- a/components/WpGutenberg.vue
+++ b/components/WpGutenberg.vue
@@ -93,7 +93,11 @@ export default {
             return this.registeredComponents.includes(componentName)
         },
         getBlockName(name = "") {
-            name = name.replace("core/", "").replace("acf/", "").toLowerCase()
+            name = name
+                .replace("core/", "")
+                .replace("acf/", "")
+                .replace("fuxt/", "")
+                .toLowerCase()
             return `gutenberg-${name}`
         },
     },


### PR DESCRIPTION
remove 'fuxt/...'  from custom component names to follow with dynamically rendered component naming conventions