### PR TITLE
updates spacer prop, styles

### DIFF
--- a/components/gutenberg/Spacer.vue
+++ b/components/gutenberg/Spacer.vue
@@ -1,19 +1,22 @@
 <template lang="html">
-    <div class="gutenberg-spacer gutenberg-block" :style="styles" />
+    <div
+        class="gutenberg-spacer gutenberg-block"
+        :style="styles"
+    />
 </template>
 
 <script>
 export default {
     props: {
         height: {
-            type: Number,
-            default: 0,
+            type: [String, Number],
+            default: "100px",
         },
     },
     computed: {
         styles() {
             return {
-                margin: `0 0 ${this.height}px 0`,
+                margin: `0 0 ${parseInt(this.height)}px 0`,
             }
         },
     },
@@ -22,5 +25,6 @@ export default {
 
 <style lang="scss" scoped>
 .gutenberg-spacer {
+    min-height: 1px;
 }
 </style>

--- a/components/gutenberg/Spacer.vue
+++ b/components/gutenberg/Spacer.vue
@@ -25,6 +25,5 @@ export default {
 
 <style lang="scss" scoped>
 .gutenberg-spacer {
-    min-height: 1px;
 }
 </style>


### PR DESCRIPTION
Gutenberg returns the pixel value as string but the component expected a Number. 
Updated to handle either values.