### PR TITLE
Fix wp-menu data parsing 

### DIFF
--- a/components/WpMenu.vue
+++ b/components/WpMenu.vue
@@ -21,6 +21,7 @@
 <script>
 // Helpers
 import _kebabCase from "lodash/kebabCase"
+import flatListToHierarchical from "~/utils/flatListToHierarchical.js"
 
 // GQL
 import MENU_BY_NAME from "~/gql/queries/MenuByName"
@@ -53,7 +54,7 @@ export default {
             const data = await this.$graphql.default.request(MENU_BY_NAME, {
                 name: this.name
             })
-            this.menuItems = data.menu?.menuItems?.nodes || []
+            this.menuItems = flatListToHierarchical(data.menu?.menuItems?.nodes || [])
             this.hasLoaded = true
             this.$emit("loaded")
         } catch (error) {

--- a/components/WpMenu.vue
+++ b/components/WpMenu.vue
@@ -1,14 +1,14 @@
 <template>
     <ul
-        v-if="menuItems.length"
+        v-if="parsedItems.length"
         :key="name"
         :class="classes"
     >
         <slot name="before" />
 
         <wp-menu-item
-            v-for="(item, i) in menuItems"
-            :key="i"
+            v-for="(item, i) in parsedItems"
+            :key="item.id || i"
             class="menu-item"
             :item="item"
             @menu-interacted="menuInteracted"
@@ -21,7 +21,7 @@
 <script>
 // Helpers
 import _kebabCase from "lodash/kebabCase"
-import flatListToHierarchical from "~/utils/flatListToHierarchical.js"
+import flatListToHierarchical from "~/utils/flatListToHierarchical"
 
 // GQL
 import MENU_BY_NAME from "~/gql/queries/MenuByName"
@@ -54,7 +54,7 @@ export default {
             const data = await this.$graphql.default.request(MENU_BY_NAME, {
                 name: this.name
             })
-            this.menuItems = flatListToHierarchical(data.menu?.menuItems?.nodes || [])
+            this.menuItems = data?.menu?.menuItems?.nodes || []
             this.hasLoaded = true
             this.$emit("loaded")
         } catch (error) {
@@ -68,6 +68,9 @@ export default {
                 `name-${_kebabCase(this.name) || "unknown"}`,
                 { "has-loaded": this.hasLoaded }
             ]
+        },
+        parsedItems() {
+            return flatListToHierarchical(this.menuItems)
         }
     },
     watch: {

--- a/components/WpMenuItem.vue
+++ b/components/WpMenuItem.vue
@@ -29,7 +29,7 @@
             class="sub-menu"
         >
             <wp-menu-item
-                v-for="(subItem, i) in getChildren"
+                v-for="(subItem, i) in children"
                 :key="`sub-${i}`"
                 class="menu-item sub-menu-item"
                 :item="subItem"
@@ -59,8 +59,8 @@ export default {
                 ...this.item.cssClasses
             ]
         },
-        getChildren() {
-            return this.item.childItems?.nodes || []
+        children() {
+            return this.item.children?.nodes || []
         },
         hasSubMenu() {
             return this.getChildren.length

--- a/gql/queries/MenuByName.gql
+++ b/gql/queries/MenuByName.gql
@@ -2,14 +2,9 @@ query MenuByName($name: ID!) {
     menu(id: $name, idType: NAME) {
         id
         name
-        menuItems(first: 30, where: { parentDatabaseId: 0 }) {
+        menuItems(first: 30) {
             nodes {
                 ...MenuItem
-                childItems {
-                    nodes {
-                        ...MenuItem
-                    }
-                }
             }
         }
     }

--- a/utils/flatListToHierarchical.js
+++ b/utils/flatListToHierarchical.js
@@ -1,18 +1,23 @@
-// Used to transform a flat list of wordpress menu items into a hierarchical tree
+/*
+ * This function transform a flat list of WordPress menu items into a hierarchical tree
+ * SEE: https://www.wpgraphql.com/docs/menus#hierarchical-data
+ */
+function flatListToHierarchical(
+    data = [],
+    { idKey = "id", parentKey = "parentId", childrenKey = "children" } = {}
+) {
+    const tree = []
+    const childrenOf = {}
+    data.forEach((item) => {
+        const newItem = { ...item }
+        const { [idKey]: id, [parentKey]: parentId = 0 } = newItem
+        childrenOf[id] = childrenOf[id] || []
+        newItem[childrenKey] = childrenOf[id]
+        parentId
+            ? (childrenOf[parentId] = childrenOf[parentId] || []).push(newItem)
+            : tree.push(newItem)
+    })
+    return tree
+}
 
-export default function(data = [],{idKey='key',parentKey='parentId',childrenKey='children'} = {}) {
-  const tree = [];
-  const childrenOf = {};
-  data.forEach((item) => {
-      const newItem = {...item};
-      const { [idKey]: id, [parentKey]: parentId = 0 } = newItem;
-      childrenOf[id] = childrenOf[id] || [];
-      newItem[childrenKey] = childrenOf[id];
-      parentId
-          ? (
-              childrenOf[parentId] = childrenOf[parentId] || []
-          ).push(newItem)
-          : tree.push(newItem);
-  });
-  return tree;
-};
+export default flatListToHierarchical

--- a/utils/flatListToHierarchical.js
+++ b/utils/flatListToHierarchical.js
@@ -1,0 +1,18 @@
+// Used to transform a flat list of wordpress menu items into a hierarchical tree
+
+export default function(data = [],{idKey='key',parentKey='parentId',childrenKey='children'} = {}) {
+  const tree = [];
+  const childrenOf = {};
+  data.forEach((item) => {
+      const newItem = {...item};
+      const { [idKey]: id, [parentKey]: parentId = 0 } = newItem;
+      childrenOf[id] = childrenOf[id] || [];
+      newItem[childrenKey] = childrenOf[id];
+      parentId
+          ? (
+              childrenOf[parentId] = childrenOf[parentId] || []
+          ).push(newItem)
+          : tree.push(newItem);
+  });
+  return tree;
+};


### PR DESCRIPTION
Add flatListToHierarchical script which converts the wordpress menu data into a hierarchical tree structure