### PR TITLE
Fuxt - WpLink

### DIFF
--- a/components/WpLink.vue
+++ b/components/WpLink.vue
@@ -60,13 +60,13 @@ export default {
             return this.to.startsWith(this.frontendUrl)
         },
         isHashLink() {
-            return this.to.startsWith("#")
+            return this.to?.startsWith("#") || false
         },
         isEmail() {
-            return this.to.includes("mailto:")
+            return this.to?.includes("mailto:") || false
         },
         isPhone() {
-            return this.to.includes("tel:")
+            return this.to?.includes("tel:") || false
         },
         isRelative() {
             let result = false


### PR DESCRIPTION
update wp-link error when there is no :to prop

Was getting these error after client deleted a button link so adding this fix here jic


<img width="1432" alt="wp-link-err" src="https://github.com/funkhaus/fuxt/assets/13562688/c32b8542-e60e-4d87-9fca-2a4d117efa32">
