### PR TITLE
Config nitro to compress assets

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -14,6 +14,9 @@ export default defineNuxtConfig({
         prerender: {
             // This helps ensure that all paths end with `/`.
             autoSubfolderIndex: true
+        },
+        compressPublicAssets: {
+            gzip: true
         }
     },
     vite: {


### PR DESCRIPTION
Configure Nitro to compress assets at build time. Generally reduces file size by 10-30%.
