### PR TITLE
fuxt - useEventListener

### DIFF
--- a/app/composables/useEventListener.ts
+++ b/app/composables/useEventListener.ts
@@ -1,0 +1,35 @@
+/**
+ * A composable to automatically register and clean up an event listener on a given target.
+ *
+ * @template T - The type of event to listen for (extends Event).
+ * @param {EventTarget | Ref<EventTarget | null>} target - The target to attach the event listener to. Can be a direct EventTarget or a ref to one.
+ * @param {string} event - The name of the event to listen for (e.g., 'click', 'keydown').
+ * @param {(e: T) => void} handler - The callback function to handle the event.
+ * @param {AddEventListenerOptions} [options] - Optional options to pass to `addEventListener`.
+ *
+ * @example
+ * ```ts
+ * const button = ref<HTMLElement | null>(null)
+ *
+ * useEventListener<MouseEvent>(button, 'click', (e) => {
+ *   console.log('Button clicked!', e)
+ * })
+ * ```
+ */
+
+export function useEventListener<T extends Event>(
+    target: EventTarget | Ref<EventTarget | null>,
+    event: string,
+    handler: (e: T) => void,
+    options?: AddEventListenerOptions
+) {
+    onMounted(() => {
+        const el = unref(target)
+        el?.addEventListener(event, handler as EventListener, options)
+    })
+
+    onBeforeUnmount(() => {
+        const el = unref(target)
+        el?.removeEventListener(event, handler as EventListener)
+    })
+}


### PR DESCRIPTION
I've seen a few places in UCLA that they forgot to remove event listener when component unmounts, which can lead to memory leaks etc.

I added a simple composable that automatically adds/removes event listener using onMount/onBeforeUnmount which can be useful for us as well.


Since we are using Vite with our Nuxt3 apps, the Vite will perform tree shaking when building a project and get rid of unused code (including custom composables as well) and will not include them in the final bundle