### PR TITLE
Fixes invalid css syntax

### DIFF
--- a/app/components/wp-content.vue
+++ b/app/components/wp-content.vue
@@ -82,7 +82,7 @@ const parsedBlocks = computed(() => {
     display: flow-root;
 
     /* Genric styles for all top level blocks */
-    :where(> .wp-block) {
+    > .wp-block {
         margin: var(--unit-margin-large) auto;
         max-width: var(--unit-max-width-large);
         padding: 0 var(--unit-gutter);


### PR DESCRIPTION
Should either be
```
.parent {
  > .some-class {
    color: red;
  }
}
```
Or
```
.parent {
  & > .some-class {
    color: red;
  }
}
```
Both work fine on all three major browsers so I'll stick with > this one. The :where() pseudo-class takes a selector list, not a combinator by itself.

A combinator like > must be between two selectors (parent > child), so you can’t start :where() with just > .come-class.