### PR TITLE
Fuxt - wp-seo: remove duplicate fetch, use usePageSeo state

### DIFF
--- a/app/components/wp-seo.vue
+++ b/app/components/wp-seo.vue
@@ -32,18 +32,36 @@ const props = defineProps({
     }
 })
 
+// WP excerpts and descriptions can contain HTML — strip it for meta tag content
+function stripHtml(str?: string): string | undefined {
+    return str?.replace(/<[^>]*>/g, '') || undefined
+}
+
 // Computeds — props → page state → site store defaults
 const parsedTitle = computed(() => props.title || pageSeo.value?.title || siteStore.settings?.title || undefined)
-const parsedDescription = computed(() => props.description || pageSeo.value?.description || siteStore.settings.description || undefined)
-const parsedImage = computed(() => props.imageUrl || pageSeo.value?.imageUrl || siteStore.settings?.themeScreenshotUrl || undefined)
+const parsedDescription = computed(() => {
+    const raw = props.description || pageSeo.value?.description || siteStore.settings?.description || undefined
+    return stripHtml(raw)
+})
+const parsedImage = computed(() =>
+    props.imageUrl
+    || pageSeo.value?.imageUrl
+    || siteStore.settings?.socialSharedImage?.src
+    || siteStore.settings?.themeScreenshotUrl
+    || undefined
+)
 
 // Set meta tags
 useSeoMeta({
     title: () => parsedTitle.value,
     ogTitle: () => parsedTitle.value,
+    twitterTitle: () => parsedTitle.value,
     description: () => parsedDescription.value,
     ogDescription: () => parsedDescription.value,
-    ogImage: () => parsedImage.value
+    twitterDescription: () => parsedDescription.value,
+    ogImage: () => parsedImage.value,
+    twitterImage: () => parsedImage.value,
+    twitterCard: 'summary_large_image'
 })
 </script>
 

--- a/app/components/wp-seo.vue
+++ b/app/components/wp-seo.vue
@@ -14,7 +14,7 @@
 
 <script setup lang="ts">
 const siteStore = useSiteStore()
-const route = useRoute()
+const pageSeo = usePageSeo()
 
 // Props
 const props = defineProps({
@@ -26,39 +26,16 @@ const props = defineProps({
         type: String,
         default: ''
     },
-    path: {
-        type: String,
-        default: ''
-    },
     imageUrl: {
         type: String,
         default: ''
     }
 })
 
-// Fetch data from WP
-const parsedPath = computed<string>(() => props.path || route.path || '')
-
-// Fetch data from WP
-const { data, error } = await useWpFetch(RequestType.POST, {
-    query: {
-        uri: parsedPath
-    },
-    pick: ['title', 'excerpt', 'content', 'featuredMedia'],
-    onResponseError() {
-        console.warn('<wp-seo> Fetch Error:', parsedPath.value)
-    }
-})
-
-// On error, set data to empty object
-if (error.value) {
-    console.warn('<wp-seo> Error fetching data:', error.value)
-}
-
-// Computeds
-const parsedTitle = computed(() => props.title || data.value?.title || siteStore.settings?.title || undefined)
-const parsedDescription = computed(() => props.description || data.value?.excerpt || data.value?.content || siteStore.settings.description || undefined)
-const parsedImage = computed(() => props.imageUrl || data.value?.featuredMedia?.src || siteStore.settings?.themeScreenshotUrl || undefined)
+// Computeds — props → page state → site store defaults
+const parsedTitle = computed(() => props.title || pageSeo.value?.title || siteStore.settings?.title || undefined)
+const parsedDescription = computed(() => props.description || pageSeo.value?.description || siteStore.settings.description || undefined)
+const parsedImage = computed(() => props.imageUrl || pageSeo.value?.imageUrl || siteStore.settings?.themeScreenshotUrl || undefined)
 
 // Set meta tags
 useSeoMeta({

--- a/app/composables/usePageSeo.ts
+++ b/app/composables/usePageSeo.ts
@@ -1,0 +1,11 @@
+type PageSeoData = {
+    title?: string
+    description?: string
+    imageUrl?: string
+}
+
+// Bridge between page-level WP fetches and wp-seo.
+// Pages set this after their useWpFetch call; wp-seo reads it instead of fetching.
+export function usePageSeo() {
+    return useState<PageSeoData>('page-seo', () => ({}))
+}

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -30,6 +30,13 @@ const { data: workData } = await useWpFetch(RequestType.POST, {
     }
 })
 
+// Publish SEO data for wp-seo (no separate request needed)
+usePageSeo().value = {
+    title: workData.value?.title,
+    description: workData.value?.excerpt,
+    imageUrl: workData.value?.featuredMedia?.src
+}
+
 // Computed properties
 const items = computed(() => {
     return workData?.value?.children?.map(item => item?.featuredMedia) || []


### PR DESCRIPTION
## Summary

- Introduces `usePageSeo()` composable (`app/composables/usePageSeo.ts`) — a Nuxt `useState` bridge that pages set after their own `useWpFetch` call
- Rewrites `wp-seo.vue` to read from `usePageSeo()` instead of making its own fetch; falls back to `siteStore` defaults
- Updates `app/pages/index.vue` to demonstrate the pattern
- Removes the `path` prop from `wp-seo` (it only existed to drive the now-removed fetch)

**Before:** `wp-seo` made a separate `POST /post?uri={path}` request on every page, doubling SSG fetch counts project-wide.

**After:** `wp-seo` reads from `useState('page-seo')`. Pages publish their already-fetched data into it with two lines:
```typescript
usePageSeo().value = {
    title: data.value?.title,
    description: data.value?.excerpt,
    imageUrl: data.value?.featuredMedia?.src
}
```
Pages that don't publish (e.g. catch-all `[slug].vue`) fall back to `siteStore.settings` title/description.

## Migration for existing projects

For each page with a `RequestType.POST` fetch, add after the fetch:
```typescript
usePageSeo().value = {
    title: data.value?.title,
    description: data.value?.excerpt,
    imageUrl: data.value?.featuredMedia?.src
}
```

For list pages that use a parent WP page's SEO (like a `/work` or `/talent` page), keep the existing parent-page fetch and pipe its result into `usePageSeo()` instead of calling `useSeoMeta()` directly.
