### PR TITLE
Fuxt - Bust Flywheel cache on server-side WP fetches

### DIFF
--- a/app/composables/useWpFetch.ts
+++ b/app/composables/useWpFetch.ts
@@ -31,6 +31,14 @@ export function useWpFetch<K extends keyof EndpointTypeMap>(endpoint: K, options
             return keysToCamelCase(data || {}) as ResponseType<K>
         },
         onRequest({ options }) {
+            if (import.meta.server) {
+                // Tell Flywheel's reverse proxy not to serve a cached response during generate/ISR
+                options.headers = {
+                    ...options.headers,
+                    'Cache-Control': 'no-cache',
+                    'Pragma': 'no-cache',
+                }
+            }
             // Add credentials to fetch request if preview enabled
             if (isPreviewEnabled.value) {
                 options.credentials = 'include'


### PR DESCRIPTION
## Summary

- Adds `Cache-Control: no-cache` and `Pragma: no-cache` headers to all server-side `useWpFetch` requests
- Flywheel's reverse proxy is instructed to always hit the WP origin during `nuxt generate` and ISR revalidation, preventing stale API responses from being served
- Headers are only sent server-side (`import.meta.server`) — browser requests are unaffected
- URLs remain unchanged so Nuxt's fetch deduplication and hydration continue to work correctly