### PR TITLE
fuxt - wp-seo: remove self-fetch, drive from useWpFetch

### DIFF
--- a/app/components/wp-seo.vue
+++ b/app/components/wp-seo.vue
@@ -14,7 +14,7 @@
 
 <script setup lang="ts">
 const siteStore = useSiteStore()
-const route = useRoute()
+const pageSeo = usePageSeo()
 
 // Props
 const props = defineProps({
@@ -26,47 +26,42 @@ const props = defineProps({
         type: String,
         default: ''
     },
-    path: {
-        type: String,
-        default: ''
-    },
     imageUrl: {
         type: String,
         default: ''
     }
 })
 
-// Fetch data from WP
-const parsedPath = computed<string>(() => props.path || route.path || '')
-
-// Fetch data from WP
-const { data, error } = await useWpFetch(RequestType.POST, {
-    query: {
-        uri: parsedPath
-    },
-    pick: ['title', 'excerpt', 'content', 'featuredMedia'],
-    onResponseError() {
-        console.warn('<wp-seo> Fetch Error:', parsedPath.value)
-    }
-})
-
-// On error, set data to empty object
-if (error.value) {
-    console.warn('<wp-seo> Error fetching data:', error.value)
+// WP excerpts and descriptions can contain HTML — strip it for meta tag content
+function stripHtml(str?: string): string | undefined {
+    return str?.replace(/<[^>]*>/g, '') || undefined
 }
 
-// Computeds
-const parsedTitle = computed(() => props.title || data.value?.title || siteStore.settings?.title || undefined)
-const parsedDescription = computed(() => props.description || data.value?.excerpt || data.value?.content || siteStore.settings.description || undefined)
-const parsedImage = computed(() => props.imageUrl || data.value?.featuredMedia?.src || siteStore.settings?.themeScreenshotUrl || undefined)
+// Computeds — props → page state → site store defaults
+const parsedTitle = computed(() => props.title || pageSeo.value?.title || siteStore.settings?.title || undefined)
+const parsedDescription = computed(() => {
+    const raw = props.description || pageSeo.value?.description || siteStore.settings?.description || undefined
+    return stripHtml(raw)
+})
+const parsedImage = computed(() =>
+    props.imageUrl
+    || pageSeo.value?.imageUrl
+    || siteStore.settings?.socialSharedImage?.src
+    || siteStore.settings?.themeScreenshotUrl
+    || undefined
+)
 
 // Set meta tags
 useSeoMeta({
     title: () => parsedTitle.value,
     ogTitle: () => parsedTitle.value,
+    twitterTitle: () => parsedTitle.value,
     description: () => parsedDescription.value,
     ogDescription: () => parsedDescription.value,
-    ogImage: () => parsedImage.value
+    twitterDescription: () => parsedDescription.value,
+    ogImage: () => parsedImage.value,
+    twitterImage: () => parsedImage.value,
+    twitterCard: 'summary_large_image'
 })
 </script>
 

--- a/app/composables/usePageSeo.ts
+++ b/app/composables/usePageSeo.ts
@@ -1,0 +1,11 @@
+type PageSeoData = {
+    title?: string
+    description?: string
+    imageUrl?: string
+}
+
+// Bridge between page-level WP fetches and wp-seo.
+// useWpFetch populates this automatically for POST requests; wp-seo reads it.
+export function usePageSeo() {
+    return useState<PageSeoData>('page-seo', () => ({}))
+}

--- a/app/composables/useWpFetch.ts
+++ b/app/composables/useWpFetch.ts
@@ -26,6 +26,21 @@ export function useWpFetch<K extends keyof EndpointTypeMap>(endpoint: K, options
     const baseURL = useRuntimeConfig().public.wordpressApiUrl
     const { enabled: isPreviewEnabled } = usePreviewMode()
 
+    const { server: serverFromCaller, seo: seoFromCaller, ...fetchOptions } = options as Record<string, unknown> & { server?: boolean, seo?: boolean }
+    const autoSeo = seoFromCaller !== false
+
+    const server = isPreviewEnabled.value
+        ? false
+        : (typeof serverFromCaller === 'boolean' ? serverFromCaller : true)
+
+    if (endpoint === RequestType.POST && autoSeo) {
+        const query = fetchOptions.query as Record<string, unknown> | undefined
+        if (query?.pick) {
+            const existing = Array.isArray(query.pick) ? query.pick as string[] : [query.pick as string]
+            query.pick = [...new Set([...existing, 'title', 'excerpt', 'featuredMedia'])]
+        }
+    }
+
     const response = useFetch(endpoint, {
         transform: (data) => {
             return keysToCamelCase(data || {}) as ResponseType<K>
@@ -37,9 +52,22 @@ export function useWpFetch<K extends keyof EndpointTypeMap>(endpoint: K, options
             }
         },
         baseURL,
-        ...options,
-        server: !isPreviewEnabled.value
+        ...fetchOptions,
+        server
     })
+
+    if (endpoint === RequestType.POST && autoSeo) {
+        const pageSeo = usePageSeo()
+        watch(response.data, (data) => {
+            const pageData = data as WpPageResponse | null
+            if (!pageData) return
+            pageSeo.value = {
+                title: pageData.title,
+                description: pageData.excerpt,
+                imageUrl: pageData.featuredMedia?.src
+            }
+        }, { immediate: true })
+    }
 
     return response
 }


### PR DESCRIPTION
## Summary

- Adds `usePageSeo` composable as shared state bridge between page fetches and `<wp-seo>`
- `useWpFetch` auto-populates `usePageSeo` for any `RequestType.POST` call — no manual wiring needed in pages
- `wp-seo` drops its own internal `useWpFetch` call and reads from `usePageSeo` instead (props → page state → site store defaults)
- Adds Twitter meta tags, HTML stripping for descriptions, and `socialSharedImage` fallback
- Adds `seo: false` opt-out on `useWpFetch` calls that should not affect SEO state
- Allows callers to pass `server: false` to opt out of SSR fetching

## Why

The previous `wp-seo` made a second WP fetch for the same post already fetched by the page — double the network requests with SEO data potentially arriving later than page data. This approach reuses the data already in flight.